### PR TITLE
Prevent error when comparing unset verbosity level

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -109,7 +109,7 @@ class Claviger(object):
                                 type=os.path.expanduser, default='~/.claviger',
                                 help='Configuration file')
         parser.add_argument('--verbose', '-v', action='count',
-                            dest='verbosity',
+                            dest='verbosity', default=0,
                     help='Add to increase make claviger chatty')
         parser.add_argument('--parallel-connections', '-p', metavar='N',
                                 type=int, default=8,


### PR DESCRIPTION
When no verbosity arguments are specified, `self.args.verbosity` would default to `None`. This is not comparable to integers, resulting in the following exception ([line 29](https://github.com/bwesterb/claviger/blob/master/src/main.py#L29)):

```
An unexpected exception occured:

    Traceback (most recent call last):
      File "/usr/local/lib/python3.4/dist-packages/claviger/main.py", line 29, in main
        if self.args.verbosity >= 2:
    TypeError: unorderable types: NoneType() >= int()
```

This pull request mitigates this.
