### PR TITLE
Add dependency on jsonschema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
                       'PyYAML',
                       'six',
                       'tarjan',
+                      'jsonschema',
                             ],
     entry_points = {
         'console_scripts': [


### PR DESCRIPTION
This is required to satisfy the import statement in [config.py](https://github.com/bwesterb/claviger/blob/master/src/config.py#L11).

I'm unsure why CI builds of previous commits did not pick up on this, though..
