### PR TITLE
Decode stdout/err bytes to strings

### DIFF
--- a/src/scp.py
+++ b/src/scp.py
@@ -39,7 +39,7 @@ class SCPSession(object):
         l.debug('executing %s', cmd)
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                   stderr=subprocess.PIPE)
-        stdout_txt, stderr_txt = p.communicate()
+        stdout_txt, stderr_txt = [x.decode('utf-8') for x in p.communicate()]
         if p.returncode != 0:
             raise interpret_scp_error(p.returncode, stderr_txt, stdout_txt)
 


### PR DESCRIPTION
In Python 3, the `stdout` and `stderr` buffers are `bytes`, and these need to be decoded as UTF-8 before being used as strings in the `interpret_scp_error` function.
